### PR TITLE
Update requirements.txt for numpy==1.22.*

### DIFF
--- a/WeatherRoutingTool/requirements.txt
+++ b/WeatherRoutingTool/requirements.txt
@@ -9,7 +9,7 @@ global_land_mask
 lxml
 matplotlib
 netcdf4 == 1.5.8
-numpy == 1.23.4
+numpy == 1.22.*
 pandas
 Pillow
 pymoo>=0.6.1


### PR DESCRIPTION
There was an issue where geonode 3.3.3 required numpy 1.22.* instead of 1.23.4 thus making it incompatible. Using a specific minor version (1.22) with a wildcard for the patch version (*) allows you to receive bug fixes, improvements, or other minor updates within the 1.22 release line without explicitly stating the exact patch version number. Thus, this also takes into consideration the issue of weatherroutingtool 0.1 requires numpy==1.23.4, but you have numpy 1.22.4 which is incompatible.